### PR TITLE
feat(N-007): 子供向け学習機能の実装（学年別コンテンツ・問題生成・進捗管理）

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,7 @@ src/
 ├─ gemini/          問題生成
 ├─ permissions/     ロールと権限制御
 ├─ user/            SQLite によるプロファイル・学習進捗の永続化
+├─ learning/        学習サービス（コンテンツ配信・問題生成・進捗集計）
 ├─ observability/   OpenTelemetry 計装（オプショナル）
 └─ sample/          Design by Contract のサンプル実装
 ```
@@ -77,6 +78,7 @@ src/
 | user | core | auth, drive, gemini |
 | drive | core | auth, permissions, user |
 | gemini | core | auth, permissions, user |
+| learning | core, domain, user, gemini | auth, permissions |
 | observability | （外部: OTel SDK） | core, domain |
 | sample | （なし） | core, domain |
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -8,9 +8,9 @@
 
 ## 現状（Status）
 
-- フェーズ：**Hardening**（N-001〜N-006 完了、次タスク選定待ち）
+- フェーズ：**Advanced**（N-001〜N-006 完了、B-001 着手中）
 - ブロッカー：なし
-- 直近の重要決定：N-006 完了・SQLite 永続化と移行手順を整備（2026-05-02）
+- 直近の重要決定：B-001 昇格・子供向け学習機能実装を開始（2026-05-02）
 
 ## ロードマップ（概略）
 
@@ -104,9 +104,23 @@
 - 依存：N-005
 - 触る領域：`src/`, `tests/`, `docs/runbook.md`
 
+### N-007 子供向け学習機能の実装
+
+- **🚧 進行中（2026-05-02〜）**
+- 目的：学年別コンテンツ配信・問題生成・進捗管理を実装し、子供が学年に合った問題を解ける機能を提供する
+- 受入条件：
+  - [ ] `Grade`（1〜6）と `Subject` による学年別コンテンツ取得ができる
+  - [ ] Gemini 連携で問題生成（`LearningService.generate_question`）が動作する
+  - [ ] 回答記録（正誤）を SQLite に保存・取得できる
+  - [ ] 進捗サマリー（科目別正答率）を取得できる
+  - [ ] メインパイプライン（`src/app.py`）に学習機能が統合されている
+  - [ ] テストが追加され CI が通過する
+- 依存：N-006
+- 触る領域：`src/learning/`, `src/domain/`, `src/app.py`, `tests/`
+
 ## Backlog（保留）
 
-- B-001 子供向け学習機能の実装（学年別コンテンツ配信・問題生成・進捗管理）
+（なし）
 
 ## GitHub Issue / Project 対応表
 
@@ -115,10 +129,11 @@
 | N-004 設定管理・エラーハンドリング強化 | [#3](https://github.com/weimaraner69-crypto/test02/issues/3) | 3-Hardening | Feature |
 | N-005 認証・権限の本番化 | [#4](https://github.com/weimaraner69-crypto/test02/issues/4) | 3-Hardening | Feature |
 | N-006 データ永続化 | [#5](https://github.com/weimaraner69-crypto/test02/issues/5) | 3-Hardening | Feature |
-| B-001 子供向け学習機能の実装 | [#6](https://github.com/weimaraner69-crypto/test02/issues/6) | 4-Advanced | Feature |
+| N-007 子供向け学習機能の実装 | [#6](https://github.com/weimaraner69-crypto/test02/issues/6) | 4-Advanced | Feature |
 
 ## 直近の変更履歴（最大10件）
 
+- 2026-05-02: B-001 → N-007 昇格（子供向け学習機能、Phase 4 Advanced 着手）
 - 2026-05-02: N-006 完了（SQLite 永続化、runbook/architecture 更新、140 passed / 97.12%）
 - 2026-05-02: N-005 完了（認証モード切り替え、RBAC、PR #8 マージ、128 passed / 96.83%）
 - 2026-05-02: N-004 完了（AppConfig 設定管理・エラーハンドリング強化、PR #7 マージ、117 passed / 98.50%）

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -69,7 +69,24 @@
   - ファイルベース DB を再オープンした後もプロファイルが取得できることを検証する
 - 担当モジュール：`src/user/`、`src/app.py`、`docs/runbook.md`
 
-<!-- 必要に応じて FR-020, FR-030 ... を追加 -->
+### FR-020 学年別学習機能
+
+- 入力：Grade（1〜6）、Subject（算数・国語・理科・社会・英語）、topic 文字列
+- 出力：
+  - 学年・科目に対応する LearningContent（タイトル・説明・サンプルトピック）
+  - Gemini 生成問題（question/answer/hints/curriculum_reference）
+  - 回答記録（正誤・日時）
+  - 科目別進捗サマリー（正答率・総問題数・正解数）
+- 動作：
+  - `LearningService` が `UserProfileService`（永続化）と `GeminiService`（問題生成）を統合する
+  - 回答記録は SQLite に保存し、進捗サマリーは集計して返す
+  - コンテンツカタログは `CONTENT_CATALOG` に静的定義する（算数・国語 各 6 学年）
+- 失敗時：
+  - Gemini が None を返した場合 → `ValidationError` を送出
+  - 進捗保存失敗 → `ValidationError` を送出
+- 担当モジュール：`src/learning/`, `src/domain/learning.py`
+
+<!-- 必要に応じて FR-030 ... を追加 -->
 
 ## 非機能要件（NFR）
 

--- a/src/app.py
+++ b/src/app.py
@@ -14,8 +14,10 @@ from src.core.exceptions import (
     DomainError,
     ValidationError,
 )
+from src.domain.learning import Subject
 from src.drive.service import DriveService
 from src.gemini.service import GeminiService
+from src.learning.service import LearningService
 from src.permissions.roles import Permission, has_permission
 from src.user.profile import UserProfileService
 
@@ -87,6 +89,23 @@ def main() -> None:
         if saved_progress is None:
             raise ValidationError("学習進捗を再取得できませんでした")
         print("学習進捗を保存しました")
+
+        # 学習機能: 学年別コンテンツ配信・問題生成
+        learning = LearningService(
+            profile_service=profile_service,
+            gemini_service=gemini,
+        )
+        content = learning.get_content_for_grade(config.gemini_grade, Subject.MATH)
+        if content is not None:
+            print(f"学年コンテンツ: {content.title}")
+
+        topic_key = config.gemini_topic
+        learning.generate_question(user["uid"], config.gemini_grade, Subject.MATH, topic_key)
+        print("学習問題を生成しました")
+
+        learning.record_answer(user["uid"], Subject.MATH, topic_key, is_correct=True)
+        summary = learning.get_progress_summary(user["uid"], Subject.MATH)
+        print(f"進捗サマリー: {summary}")
 
     except AuthenticationError as e:
         logger.error("認証エラー: %s", e)

--- a/src/domain/learning.py
+++ b/src/domain/learning.py
@@ -1,0 +1,147 @@
+"""
+学習ドメイン：科目・学年・コンテンツカタログ・クイズ結果の定義
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from src.core.exceptions import ValidationError
+
+
+class Subject(Enum):
+    """学習科目"""
+
+    MATH = "算数"
+    JAPANESE = "国語"
+    SCIENCE = "理科"
+    SOCIAL = "社会"
+    ENGLISH = "英語"
+
+
+def validate_grade(grade: int) -> int:
+    """学年を検証する（1〜6）。範囲外は ValidationError を送出する。"""
+    if not isinstance(grade, int) or grade < 1 or grade > 6:
+        raise ValidationError(f"学年は 1〜6 の整数で指定してください: {grade!r}")
+    return grade
+
+
+@dataclass
+class LearningContent:
+    """学年・科目に対応する学習コンテンツ"""
+
+    subject: Subject
+    grade: int
+    title: str
+    description: str
+    sample_topics: list[str] = field(default_factory=list)
+
+
+# -----------------------------------------------------------------
+# コンテンツカタログ（算数・国語 各6学年、小学校学習指導要領準拠）
+# -----------------------------------------------------------------
+CONTENT_CATALOG: dict[tuple[Subject, int], LearningContent] = {
+    # ── 算数 ──
+    (Subject.MATH, 1): LearningContent(
+        subject=Subject.MATH,
+        grade=1,
+        title="数と計算の基礎",
+        description="10 までの数の読み書きとたし算・ひき算の基礎を学ぶ。",
+        sample_topics=["1〜10 の数", "たし算", "ひき算", "大きさくらべ"],
+    ),
+    (Subject.MATH, 2): LearningContent(
+        subject=Subject.MATH,
+        grade=2,
+        title="かけ算と図形",
+        description="九九のかけ算を習得し、三角形・四角形などの図形を学ぶ。",
+        sample_topics=["九九", "かけ算", "三角形", "四角形", "長さの単位"],
+    ),
+    (Subject.MATH, 3): LearningContent(
+        subject=Subject.MATH,
+        grade=3,
+        title="わり算と小数・分数入門",
+        description="わり算の意味を理解し、小数と分数の初歩を学ぶ。",
+        sample_topics=["わり算", "小数", "分数", "円と球", "重さの単位"],
+    ),
+    (Subject.MATH, 4): LearningContent(
+        subject=Subject.MATH,
+        grade=4,
+        title="大きな数・面積と図形",
+        description="億や兆の大きな数、面積の計算、垂直・平行などの図形を学ぶ。",
+        sample_topics=["億・兆", "面積", "垂直と平行", "四角形の種類", "折れ線グラフ"],
+    ),
+    (Subject.MATH, 5): LearningContent(
+        subject=Subject.MATH,
+        grade=5,
+        title="分数の計算と割合",
+        description="分数のたし算・ひき算・かけ算、割合・百分率を学ぶ。",
+        sample_topics=["分数のたし算", "分数のひき算", "割合", "百分率", "単位量あたり"],
+    ),
+    (Subject.MATH, 6): LearningContent(
+        subject=Subject.MATH,
+        grade=6,
+        title="比と速さ・文字式入門",
+        description="比・速さ・文字を使った式など中学数学への橋渡しを学ぶ。",
+        sample_topics=["比", "速さ", "文字と式", "円の面積", "体積"],
+    ),
+    # ── 国語 ──
+    (Subject.JAPANESE, 1): LearningContent(
+        subject=Subject.JAPANESE,
+        grade=1,
+        title="ひらがな・カタカナと読み書き",
+        description="ひらがな・カタカナの読み書き、基本的な漢字 80 字を学ぶ。",
+        sample_topics=["ひらがな", "カタカナ", "漢字80字", "文の組み立て", "音読"],
+    ),
+    (Subject.JAPANESE, 2): LearningContent(
+        subject=Subject.JAPANESE,
+        grade=2,
+        title="漢字と文章読解の基礎",
+        description="漢字 160 字の習得と、短い文章の読解・作文を学ぶ。",
+        sample_topics=["漢字160字", "文章読解", "作文", "主語・述語", "句読点"],
+    ),
+    (Subject.JAPANESE, 3): LearningContent(
+        subject=Subject.JAPANESE,
+        grade=3,
+        title="物語・説明文の読解",
+        description="物語文・説明文を読み、段落・要約の方法を学ぶ。",
+        sample_topics=["物語文", "説明文", "段落", "要約", "漢字200字"],
+    ),
+    (Subject.JAPANESE, 4): LearningContent(
+        subject=Subject.JAPANESE,
+        grade=4,
+        title="ことわざ・慣用句と文法基礎",
+        description="ことわざ・慣用句を習得し、修飾語・接続語などの文法を学ぶ。",
+        sample_topics=["ことわざ", "慣用句", "修飾語", "接続語", "漢字200字"],
+    ),
+    (Subject.JAPANESE, 5): LearningContent(
+        subject=Subject.JAPANESE,
+        grade=5,
+        title="敬語と文学・報告文",
+        description="敬語の使い方、文学的文章の読解、報告文・意見文の書き方を学ぶ。",
+        sample_topics=["敬語", "詩・俳句", "報告文", "意見文", "漢字185字"],
+    ),
+    (Subject.JAPANESE, 6): LearningContent(
+        subject=Subject.JAPANESE,
+        grade=6,
+        title="論説文・古典入門と表現技法",
+        description="論説文の読解、古文・漢文の入門、表現技法を学ぶ。",
+        sample_topics=["論説文", "古文入門", "漢文入門", "表現技法", "漢字181字"],
+    ),
+}
+
+
+def get_content(subject: Subject, grade: int) -> LearningContent | None:
+    """科目と学年に対応する LearningContent を返す。存在しない場合は None。"""
+    return CONTENT_CATALOG.get((subject, grade))
+
+
+@dataclass
+class QuizResult:
+    """クイズ回答結果"""
+
+    uid: str
+    subject: Subject
+    topic: str
+    is_correct: bool
+    answered_at: str  # ISO 8601 UTC（例: "2026-05-02T10:00:00Z"）

--- a/src/learning/service.py
+++ b/src/learning/service.py
@@ -1,0 +1,107 @@
+"""
+学習サービス：コンテンツ配信・問題生成・回答記録・進捗集計
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from src.core.exceptions import ValidationError
+from src.domain.learning import LearningContent, Subject, get_content
+
+if TYPE_CHECKING:
+    from src.gemini.service import GeminiService
+    from src.user.profile import UserProfileService
+
+
+def _topic_key(subject: Subject, topic: str) -> str:
+    """UserProfileService に渡すトピックキーを生成する。"""
+    return f"{subject.value}:{topic}"
+
+
+class LearningService:
+    """学習機能の統合サービス。"""
+
+    def __init__(
+        self,
+        profile_service: UserProfileService,
+        gemini_service: GeminiService,
+    ) -> None:
+        self._profile = profile_service
+        self._gemini = gemini_service
+
+    def get_content_for_grade(self, grade: int, subject: Subject) -> LearningContent | None:
+        """学年と科目に対応するコンテンツを返す。"""
+        return get_content(subject, grade)
+
+    def generate_question(self, uid: str, grade: int, subject: Subject, topic: str) -> dict:
+        """Gemini で問題を生成して返す。
+        生成結果が None の場合は ValidationError を送出する。
+        """
+        result = self._gemini.generate_question(
+            context=f"{subject.value} {topic}",
+            topic=topic,
+            grade=grade,
+        )
+        if result is None:
+            raise ValidationError(
+                f"Gemini から問題を取得できませんでした: "
+                f"subject={subject.value}, grade={grade}, topic={topic}"
+            )
+        return result
+
+    def record_answer(self, uid: str, subject: Subject, topic: str, is_correct: bool) -> None:
+        """回答結果を学習進捗として保存する。
+        既存進捗がある場合は total/correct をインクリメントし、
+        ない場合は新規エントリを作成する。
+        保存失敗（False 返却）時は ValidationError を送出する。
+        """
+        key = _topic_key(subject, topic)
+        existing = self._profile.get_learning_progress(uid, key)
+
+        answered_at = datetime.now(tz=UTC).isoformat().replace("+00:00", "Z")
+
+        if existing is not None:
+            progress = dict(existing)
+            progress["total"] = existing.get("total", 0) + 1
+            progress["correct"] = existing.get("correct", 0) + (1 if is_correct else 0)
+            progress["last_answered_at"] = answered_at
+        else:
+            progress = {
+                "subject": subject.value,
+                "topic": topic,
+                "total": 1,
+                "correct": 1 if is_correct else 0,
+                "last_answered_at": answered_at,
+            }
+
+        ok = self._profile.set_learning_progress(uid, key, progress)
+        if not ok:
+            raise ValidationError(
+                f"学習進捗の保存に失敗しました: uid={uid}, subject={subject.value}, topic={topic}"
+            )
+
+    def get_progress_summary(self, uid: str, subject: Subject) -> dict:
+        """科目全体の進捗サマリーを返す。
+        対象科目のすべての topic を取得し、正答率・総問題数・正解数を集計する。
+        """
+        total = 0
+        correct = 0
+
+        # UserProfileService の公開 API 経由で全件取得する
+        all_progress = self._profile.list_all_learning_progress(uid)
+
+        for progress in all_progress:
+            # subject フィールドで対象科目のみに絞り込む
+            if progress.get("subject") == subject.value:
+                total += progress.get("total", 0)
+                correct += progress.get("correct", 0)
+
+        accuracy = correct / total if total > 0 else 0.0
+        return {
+            "subject": subject.value,
+            "total": total,
+            "correct": correct,
+            "accuracy": accuracy,
+        }

--- a/src/user/profile.py
+++ b/src/user/profile.py
@@ -108,6 +108,20 @@ class UserProfileService:
             )
         return True
 
+    def list_all_learning_progress(self, uid: str) -> list[dict]:
+        """指定ユーザーのすべての学習進捗を一覧で返す。"""
+        rows = self._connection.execute(
+            "SELECT progress_json FROM learning_progress WHERE uid = ?",
+            (uid,),
+        ).fetchall()
+        result: list[dict] = []
+        for (progress_json,) in rows:
+            try:
+                result.append(self._deserialize_payload(progress_json))
+            except Exception:
+                continue
+        return result
+
     def list_family_members(self, admin_uid: str) -> list:
         """
         管理者の家族メンバー一覧取得（雛形）

--- a/tests/test_domain_learning.py
+++ b/tests/test_domain_learning.py
@@ -1,0 +1,100 @@
+"""
+ドメイン層の学習モジュール（learning.py）に対する単体テスト
+"""
+
+from __future__ import annotations
+
+import pytest
+from src.core.exceptions import ValidationError
+from src.domain.learning import (
+    CONTENT_CATALOG,
+    LearningContent,
+    Subject,
+    get_content,
+    validate_grade,
+)
+
+
+# ─────────────────────────────────────────────
+# validate_grade: 正常系
+# ─────────────────────────────────────────────
+@pytest.mark.parametrize("grade", [1, 3, 6])
+def test_validate_grade_valid(grade: int) -> None:
+    """境界値 1・中間値 3・上限 6 はそのまま返す。"""
+    assert validate_grade(grade) == grade
+
+
+# ─────────────────────────────────────────────
+# validate_grade: 異常系
+# ─────────────────────────────────────────────
+@pytest.mark.parametrize("grade", [0, 7, -1, "3"])
+def test_validate_grade_invalid(grade) -> None:
+    """0・7・負数・文字列は ValidationError を送出する。"""
+    with pytest.raises(ValidationError):
+        validate_grade(grade)
+
+
+# ─────────────────────────────────────────────
+# CONTENT_CATALOG: 算数 6 学年すべて存在する
+# ─────────────────────────────────────────────
+@pytest.mark.parametrize("grade", range(1, 7))
+def test_content_catalog_math_all_grades(grade: int) -> None:
+    """CONTENT_CATALOG に (Subject.MATH, 1)〜(Subject.MATH, 6) がある。"""
+    assert (Subject.MATH, grade) in CONTENT_CATALOG
+
+
+# ─────────────────────────────────────────────
+# CONTENT_CATALOG: 国語 6 学年すべて存在する
+# ─────────────────────────────────────────────
+@pytest.mark.parametrize("grade", range(1, 7))
+def test_content_catalog_japanese_all_grades(grade: int) -> None:
+    """CONTENT_CATALOG に (Subject.JAPANESE, 1)〜(Subject.JAPANESE, 6) がある。"""
+    assert (Subject.JAPANESE, grade) in CONTENT_CATALOG
+
+
+# ─────────────────────────────────────────────
+# get_content: 登録済みエントリを返す
+# ─────────────────────────────────────────────
+def test_get_content_math_grade3_returns_content() -> None:
+    """算数・3 年は登録済みなので LearningContent インスタンスを返す。"""
+    content = get_content(Subject.MATH, 3)
+    assert isinstance(content, LearningContent)
+
+
+# ─────────────────────────────────────────────
+# get_content: 未登録エントリは None
+# ─────────────────────────────────────────────
+def test_get_content_unregistered_returns_none() -> None:
+    """理科・1 年はカタログ未登録なので None を返す。"""
+    assert get_content(Subject.SCIENCE, 1) is None
+
+
+# ─────────────────────────────────────────────
+# LearningContent: フィールドが空でない
+# ─────────────────────────────────────────────
+def test_learning_content_fields_are_nonempty() -> None:
+    """算数・3 年コンテンツのフィールドがすべて有効な値を持つ。"""
+    content = get_content(Subject.MATH, 3)
+    assert content is not None
+    assert content.grade == 3
+    assert content.subject == Subject.MATH
+    assert content.title != ""
+    assert len(content.sample_topics) > 0
+
+
+# ─────────────────────────────────────────────
+# Subject Enum: value が日本語
+# ─────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "subject, expected_value",
+    [
+        (Subject.MATH, "算数"),
+        (Subject.JAPANESE, "国語"),
+        (Subject.SCIENCE, "理科"),
+        (Subject.SOCIAL, "社会"),
+        (Subject.ENGLISH, "英語"),
+    ],
+)
+def test_subject_enum_value_is_japanese(subject: Subject, expected_value: str) -> None:
+    """Subject の value がすべて日本語文字列である。"""
+    assert subject.value == expected_value

--- a/tests/test_learning_service.py
+++ b/tests/test_learning_service.py
@@ -1,0 +1,144 @@
+"""
+学習サービス（learning/service.py）に対する単体テスト
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from src.core.exceptions import ValidationError
+from src.domain.learning import LearningContent, Subject
+from src.gemini.service import GeminiService
+from src.learning.service import LearningService
+from src.user.profile import UserProfileService
+
+# ─────────────────────────────────────────────
+# フィクスチャ
+# ─────────────────────────────────────────────
+
+
+@pytest.fixture
+def svc():
+    """インメモリ DB + モック GeminiService の LearningService を返す。"""
+    profile = UserProfileService(":memory:")
+    gemini = GeminiService(api_key="test-key")
+    return LearningService(profile_service=profile, gemini_service=gemini)
+
+
+@pytest.fixture
+def svc_with_uid(svc):
+    """テスト用 uid に紐づいたプロファイルをセットアップ済みのサービスと uid を返す。"""
+    uid = "test-uid-001"
+    svc._profile.set_profile(uid, {"uid": uid, "role": "student"})
+    return svc, uid
+
+
+# ─────────────────────────────────────────────
+# get_content_for_grade
+# ─────────────────────────────────────────────
+
+
+def test_get_content_for_grade_math_grade3(svc) -> None:
+    """登録済みの算数・3 年は LearningContent を返す。"""
+    result = svc.get_content_for_grade(3, Subject.MATH)
+    assert isinstance(result, LearningContent)
+
+
+def test_get_content_for_grade_unregistered_returns_none(svc) -> None:
+    """カタログ未登録の理科・1 年は None を返す。"""
+    assert svc.get_content_for_grade(1, Subject.SCIENCE) is None
+
+
+# ─────────────────────────────────────────────
+# generate_question
+# ─────────────────────────────────────────────
+
+
+def test_generate_question_returns_question_key(svc_with_uid) -> None:
+    """正常時: 戻り値 dict に "question" キーが含まれる。"""
+    service, uid = svc_with_uid
+    result = service.generate_question(uid, grade=3, subject=Subject.MATH, topic="わり算")
+    assert "question" in result
+
+
+def test_generate_question_gemini_none_raises(svc_with_uid) -> None:
+    """Gemini が None を返す場合は ValidationError を送出する。"""
+    service, uid = svc_with_uid
+    with (
+        patch.object(service._gemini, "generate_question", return_value=None),
+        pytest.raises(ValidationError),
+    ):
+        service.generate_question(uid, grade=3, subject=Subject.MATH, topic="わり算")
+
+
+# ─────────────────────────────────────────────
+# record_answer / get_progress_summary
+# ─────────────────────────────────────────────
+
+
+def test_record_answer_correct_once(svc_with_uid) -> None:
+    """正解 1 回記録後: total=1, correct=1。"""
+    service, uid = svc_with_uid
+    service.record_answer(uid, Subject.MATH, "わり算", is_correct=True)
+    summary = service.get_progress_summary(uid, Subject.MATH)
+    assert summary["total"] == 1
+    assert summary["correct"] == 1
+
+
+def test_record_answer_incorrect_once(svc_with_uid) -> None:
+    """不正解 1 回記録後: total=1, correct=0。"""
+    service, uid = svc_with_uid
+    service.record_answer(uid, Subject.MATH, "わり算", is_correct=False)
+    summary = service.get_progress_summary(uid, Subject.MATH)
+    assert summary["total"] == 1
+    assert summary["correct"] == 0
+
+
+def test_record_answer_accuracy_multiple_attempts(svc_with_uid) -> None:
+    """正解 2・不正解 1 → total=3, correct=2, accuracy≈0.667。"""
+    service, uid = svc_with_uid
+    service.record_answer(uid, Subject.MATH, "わり算", is_correct=True)
+    service.record_answer(uid, Subject.MATH, "わり算", is_correct=True)
+    service.record_answer(uid, Subject.MATH, "わり算", is_correct=False)
+    summary = service.get_progress_summary(uid, Subject.MATH)
+    assert summary["total"] == 3
+    assert summary["correct"] == 2
+    assert abs(summary["accuracy"] - 2 / 3) < 1e-6
+
+
+def test_record_answer_different_topics_independent(svc_with_uid) -> None:
+    """別トピックの記録は互いに影響しない。"""
+    service, uid = svc_with_uid
+    service.record_answer(uid, Subject.MATH, "わり算", is_correct=True)
+    service.record_answer(uid, Subject.MATH, "小数", is_correct=False)
+    summary = service.get_progress_summary(uid, Subject.MATH)
+    assert summary["total"] == 2
+    assert summary["correct"] == 1
+
+
+def test_get_progress_summary_no_data(svc_with_uid) -> None:
+    """回答記録がない場合: total=0, correct=0, accuracy=0.0。"""
+    service, uid = svc_with_uid
+    summary = service.get_progress_summary(uid, Subject.MATH)
+    assert summary["total"] == 0
+    assert summary["correct"] == 0
+    assert summary["accuracy"] == 0.0
+
+
+def test_get_progress_summary_excludes_other_subjects(svc_with_uid) -> None:
+    """算数で記録後、国語のサマリーは total=0 のままである。"""
+    service, uid = svc_with_uid
+    service.record_answer(uid, Subject.MATH, "わり算", is_correct=True)
+    japanese_summary = service.get_progress_summary(uid, Subject.JAPANESE)
+    assert japanese_summary["total"] == 0
+
+
+def test_record_answer_save_failure_raises(svc_with_uid) -> None:
+    """set_learning_progress が False を返す場合は ValidationError を送出する。"""
+    service, uid = svc_with_uid
+    with (
+        patch.object(service._profile, "set_learning_progress", return_value=False),
+        pytest.raises(ValidationError),
+    ):
+        service.record_answer(uid, Subject.MATH, "わり算", is_correct=True)


### PR DESCRIPTION
## 概要

N-007「子供向け学習機能の実装」：学年別コンテンツ配信・Gemini 問題生成・進捗管理を新規実装した。

## 変更内容

### 新規ファイル
- `src/domain/learning.py` — 科目・学年・コンテンツカタログのドメイン型定義
- `src/learning/__init__.py` — パッケージマーカー
- `src/learning/service.py` — LearningService（コンテンツ配信・問題生成・回答記録・進捗集計）
- `tests/test_domain_learning.py` — domain/learning.py 単体テスト（27 ケース）
- `tests/test_learning_service.py` — learning/service.py 単体テスト（11 ケース）

### 変更ファイル
- `src/app.py` — LearningService を main() パイプラインに統合
- `src/user/profile.py` — `list_all_learning_progress(uid)` パブリック API を追加
- `docs/requirements.md` — FR-020「学年別学習機能」を追記
- `docs/architecture.md` — learning モジュールをモジュール一覧・依存ルールに追記

## 動作確認

| チェック | 結果 |
|---|---|
| ruff check | ✅ 0 errors |
| ruff format | ✅ no changes |
| mypy | ✅ no issues in 51 files |
| pytest | ✅ 178 passed |
| coverage | ✅ 97.30%（閾値 80%） |
| get_errors | ✅ No errors found |

## 監査結果

3 監査エージェント（spec / security / reliability）を並列実行。  
Must 指摘 2 件を全て修正済み。

1. `src/learning/service.py`: `_connection` 直接アクセス → `list_all_learning_progress()` パブリック API 経由に変更
2. `docs/architecture.md`: learning モジュール未登録 → 追記済み

Closes #6
