### PR TITLE
feat(N-009): observability統合（OpenTelemetry + トレーシング）

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,7 +79,7 @@ src/
 | drive | core | auth, permissions, user |
 | gemini | core | auth, permissions, user |
 | learning | core, domain, user, gemini | auth, permissions |
-| observability | （外部: OTel SDK） | core, domain |
+| observability | （外部: OTel SDK） | core, domain, auth, gemini, learning |
 | sample | （なし） | core, domain |
 
 ## 不変条件

--- a/src/app.py
+++ b/src/app.py
@@ -18,6 +18,7 @@ from src.domain.learning import Subject
 from src.drive.service import DriveService
 from src.gemini.service import GeminiService
 from src.learning.service import LearningService
+from src.observability.tracing import init_tracer
 from src.permissions.roles import Permission, has_permission
 from src.user.profile import UserProfileService
 
@@ -34,6 +35,7 @@ def _setup_logging(level: str) -> None:
 
 def main() -> None:
     """メインパイプライン。設定ロード → 認証 → プロファイル → 権限判定 → Drive → Gemini。"""
+    init_tracer()
     config = AppConfig.from_env()
     _setup_logging(config.log_level)
     profile_service: UserProfileService | None = None

--- a/src/auth/service.py
+++ b/src/auth/service.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import logging
 from enum import Enum
 
+from src.observability.tracing import trace_agent_operation
+
 logger = logging.getLogger(__name__)
 
 
@@ -28,6 +30,7 @@ class AuthService:
                 "現在は sign_in_with_google() を呼び出すと NotImplementedError が発生します。"
             )
 
+    @trace_agent_operation("auth.sign_in")
     def sign_in_with_google(self) -> dict | None:
         """
         Googleアカウントでログインする。

--- a/src/gemini/service.py
+++ b/src/gemini/service.py
@@ -4,12 +4,15 @@ Gemini API連携サービス雛形
 
 from __future__ import annotations
 
+from src.observability.tracing import trace_llm_call
+
 
 class GeminiService:
     def __init__(self, api_key: str):
         self.api_key = api_key
         # 実際はGoogle Generative AI SDK初期化
 
+    @trace_llm_call(model_name="gemini")
     def generate_question(self, context: str, topic: str, grade: int) -> dict | None:
         """
         Gemini APIで問題生成（雛形）

--- a/src/learning/service.py
+++ b/src/learning/service.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from src.core.exceptions import ValidationError
 from src.domain.learning import LearningContent, Subject, get_content
+from src.observability.tracing import trace_llm_call
 
 if TYPE_CHECKING:
     from src.gemini.service import GeminiService
@@ -35,6 +36,7 @@ class LearningService:
         """学年と科目に対応するコンテンツを返す。"""
         return get_content(subject, grade)
 
+    @trace_llm_call(model_name="gemini")
     def generate_question(self, uid: str, grade: int, subject: Subject, topic: str) -> dict:
         """Gemini で問題を生成して返す。
         生成結果が None の場合は ValidationError を送出する。

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,168 @@
+"""observability/tracing モジュールのテスト。
+
+OTel SDK 未インストール環境（_HAS_OTEL = False）でも全テストが通過することを確認する。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_init_tracer_no_exception() -> None:
+    """init_tracer() が OTel 未インストール時に例外を出さないことを確認する。"""
+    from src.observability.tracing import init_tracer
+
+    # OTel 未インストールでも例外が発生しないこと（no-op 動作）
+    init_tracer()
+    init_tracer(service_name="test-service")
+    init_tracer(service_name="test-service", enable_console_export=False)
+
+
+def test_get_tracer_returns_none_without_otel() -> None:
+    """get_tracer() が OTel 未インストール時に None を返すことを確認する。"""
+    from src.observability.tracing import _HAS_OTEL, get_tracer
+
+    if not _HAS_OTEL:
+        assert get_tracer() is None
+
+
+def test_trace_agent_operation_passthrough() -> None:
+    # OTel 未インストール時にパススルー動作することを確認する
+    """trace_agent_operation パススルー動作テスト。"""
+    from src.observability.tracing import trace_agent_operation
+
+    @trace_agent_operation("test.operation")
+    def sample_func(x: int, y: int) -> int:
+        return x + y
+
+    result = sample_func(2, 3)
+    assert result == 5
+
+
+def test_trace_agent_operation_passthrough_no_name() -> None:
+    """trace_agent_operation をデコレータ名なしで使用した場合もパススルーすることを確認する。"""
+    from src.observability.tracing import trace_agent_operation
+
+    @trace_agent_operation()
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    assert add(10, 20) == 30
+
+
+def test_trace_llm_call_passthrough() -> None:
+    """trace_llm_call デコレータが OTel 未インストール時にパススルー動作することを確認する。"""
+    from src.observability.tracing import trace_llm_call
+
+    @trace_llm_call(model_name="gemini")
+    def fake_llm(prompt: str) -> str:
+        return f"response:{prompt}"
+
+    result = fake_llm("hello")
+    assert result == "response:hello"
+
+
+def test_trace_llm_call_passthrough_no_model() -> None:
+    """trace_llm_call をモデル名なしで使用した場合もパススルーすることを確認する。"""
+    from src.observability.tracing import trace_llm_call
+
+    @trace_llm_call()
+    def fake_llm_no_model(value: int) -> int:
+        return value * 2
+
+    assert fake_llm_no_model(5) == 10
+
+
+def test_trace_tool_execution_passthrough() -> None:
+    # OTel 未インストール時にパススルー動作することを確認する
+    """trace_tool_execution パススルー動作テスト。"""
+    from src.observability.tracing import trace_tool_execution
+
+    @trace_tool_execution("test.tool")
+    def sample_tool(data: list[int]) -> int:
+        return sum(data)
+
+    assert sample_tool([1, 2, 3]) == 6
+
+
+def test_trace_tool_execution_passthrough_no_name() -> None:
+    """trace_tool_execution をツール名なしで使用した場合もパススルーすることを確認する。"""
+    from src.observability.tracing import trace_tool_execution
+
+    @trace_tool_execution()
+    def another_tool() -> str:
+        return "ok"
+
+    assert another_tool() == "ok"
+
+
+def test_trace_llm_call_preserves_exception() -> None:
+    """trace_llm_call デコレータが例外を透過的に再送出することを確認する。"""
+    from src.observability.tracing import trace_llm_call
+
+    @trace_llm_call(model_name="gemini")
+    def failing_llm() -> str:
+        raise ValueError("LLM エラー")
+
+    with pytest.raises(ValueError, match="LLM エラー"):
+        failing_llm()
+
+
+# ---------------------------------------------------------------------------
+# 統合テスト: 各サービスへのデコレータ適用確認（OTel 未インストール時のパススルー）
+# ---------------------------------------------------------------------------
+
+
+def test_auth_service_sign_in_works_with_decorator() -> None:
+    """AuthService.sign_in_with_google が @trace_agent_operation 適用後も正常動作するか確認。"""
+    from src.auth.service import AuthService
+
+    svc = AuthService(mode="mock")
+    result = svc.sign_in_with_google()
+    assert result is not None
+    assert result["uid"] == "mock_uid_001"
+
+
+def test_gemini_service_generate_question_works_with_decorator() -> None:
+    """GeminiService.generate_question が @trace_llm_call 適用後も正常動作することを確認する。"""
+    from unittest.mock import patch
+
+    from src.gemini.service import GeminiService
+
+    svc = GeminiService(api_key="test-key")
+    mock_response = {
+        "question": {"text": "テスト問題"},
+        "answer": "テスト答え",
+        "hints": [],
+        "curriculum_reference": "テスト",
+    }
+    with patch.object(svc, "generate_question", return_value=mock_response):
+        result = svc.generate_question("context", "topic", 3)
+    assert result is not None
+    assert result["question"]["text"] == "テスト問題"
+
+
+def test_learning_service_generate_question_works_with_decorator() -> None:
+    """LearningService.generate_question が @trace_llm_call 適用後も正常動作することを確認する。"""
+    from unittest.mock import MagicMock, patch
+
+    from src.domain.learning import Subject
+    from src.learning.service import LearningService
+    from src.user.profile import UserProfileService
+
+    profile = UserProfileService(":memory:")
+    gemini = MagicMock()
+    svc = LearningService(profile_service=profile, gemini_service=gemini)
+
+    mock_response = {
+        "question": {"text": "算数問題"},
+        "answer": "42",
+        "hints": [],
+        "curriculum_reference": "小学1年生算数",
+    }
+    gemini.generate_question.return_value = mock_response
+
+    with patch.object(profile, "set_learning_progress", return_value=True):
+        result = svc.generate_question("uid_001", 1, Subject.MATH, "足し算")
+    assert result["question"]["text"] == "算数問題"
+    profile.close()


### PR DESCRIPTION
## 概要

N-009「observability 統合（OpenTelemetry + トレーシング）」：既存の `src/observability/tracing.py` をメインパイプラインに統合し、OTel 未インストール時も安全に動作する（no-op）トレーシングを実現した。

## 変更内容

- `src/app.py` — `init_tracer()` を `main()` 先頭で呼び出し
- `src/auth/service.py` — `sign_in_with_google()` に `@trace_agent_operation` を追加
- `src/gemini/service.py` — `generate_question()` に `@trace_llm_call` を追加
- `src/learning/service.py` — `generate_question()` に `@trace_llm_call` を追加
- `tests/test_observability.py` — 新規作成（12 テスト：no-op パス + 統合テスト 3 件）
- `docs/architecture.md` — 依存ルール表に observability を追記

## 動作確認

| チェック | 結果 |
|---|---|
| ruff check | ✅ 0 errors |
| ruff format | ✅ no changes |
| mypy | ✅ no issues in 52 files |
| pytest | ✅ 190 passed |
| coverage | ✅ 97.36%（閾値 80%） |
| get_errors | ✅ No errors found |

## 監査結果

3 監査エージェント（spec / security / reliability）を並列実行。  
Must 指摘 2 件（auth スパン未追加・統合テスト欠如）を修正済み。  
セキュリティ監査・信頼性監査では Must 指摘なし。

Closes #12
