### PR TITLE
feat(N-010): CLI/runbook整備（Makefile・Dockerfile・実行手順）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# MiraStudy バックエンド - Docker イメージ
+# ビルド: docker build -t mirastudy:latest .
+# 実行:   docker run --rm --env-file .env -v "$(pwd)/data:/app/data" mirastudy:latest
+
+FROM python:3.11-slim
+
+# 作業ディレクトリの設定
+WORKDIR /app
+
+# uv のインストール
+RUN pip install --no-cache-dir uv
+
+# 依存関係ファイルのコピーと依存インストール
+COPY pyproject.toml uv.lock ./
+RUN uv sync --no-dev --frozen
+
+# ソースコードのコピー
+COPY src/ ./src/
+COPY ci/ ./ci/
+COPY configs/ ./configs/
+COPY .env.example ./
+
+# データディレクトリの作成
+RUN mkdir -p data
+
+# 実行ユーザー（root 不使用）
+RUN adduser --disabled-password --gecos "" appuser && chown -R appuser /app
+USER appuser
+
+# 環境変数のデフォルト値（.env でオーバーライド可）
+ENV AUTH_MODE=mock \
+    DATABASE_PATH=data/mirastudy.db \
+    LOG_LEVEL=INFO \
+    GEMINI_TOPIC=算数 \
+    GEMINI_GRADE=3 \
+    DRIVE_FOLDER_ID=folder1
+
+# エントリポイント
+CMD ["uv", "run", "python", "-m", "src.app"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+# MiraStudy - 開発・運用コマンド集
+# 使用方法: source .venv/bin/activate && make <target>
+
+.PHONY: help setup run lint format typecheck test ci docker-build docker-run
+
+# デフォルトターゲット
+help:
+	@echo "利用可能なコマンド:"
+	@echo "  make setup        - 依存パッケージのインストール"
+	@echo "  make run          - アプリケーション実行"
+	@echo "  make lint         - リンター実行（ruff）"
+	@echo "  make format       - フォーマットチェック（ruff format）"
+	@echo "  make typecheck    - 型チェック実行（mypy）"
+	@echo "  make test         - テスト実行（pytest + coverage）"
+	@echo "  make ci           - ローカル CI 全ステップ実行"
+	@echo "  make docker-build - Docker イメージをビルド"
+	@echo "  make docker-run   - Docker コンテナを実行"
+
+# 依存パッケージのインストール
+setup:
+	python -m pip install -q --upgrade pip setuptools wheel && python -m pip install -q -e ".[dev]"
+
+# アプリケーション実行
+run:
+	python -m src.app
+
+# リンター
+lint:
+	ruff check .
+
+# フォーマットチェック
+format:
+	ruff format --check .
+
+# 型チェック（テストディレクトリを含める）
+typecheck:
+	mypy src/ tests/ --ignore-missing-imports
+
+# テスト実行（カバレッジ付き）
+test:
+	pytest -q --tb=short --cov=src --cov-report=term-missing
+
+# ローカル CI 全ステップ
+ci: lint format typecheck test
+	@echo "✅ CI 全ステップ完了"
+
+# Docker イメージをビルド
+docker-build:
+	docker build -t mirastudy:latest .
+
+# Docker コンテナを実行
+docker-run:
+	docker run --rm \
+		--env-file .env \
+		-v "$(PWD)/data:/app/data" \
+		mirastudy:latest
+

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -51,6 +51,24 @@ cp .env.example .env
 
 ## 代表コマンド
 
+### ローカル開発コマンド（make 推奨）
+
+```bash
+# セットアップ
+make setup
+
+# テスト実行（カバレッジ付き）
+make test
+
+# ローカル CI 全ステップ（lint/format/typecheck/test）
+make ci
+
+# 個別コマンド
+make lint         # リンター
+make format       # フォーマットチェック
+make typecheck    # 型チェック
+```
+
 ### 静的解析
 
 ```bash
@@ -74,16 +92,44 @@ Copilot エージェントの場合は `get_errors` ツール（filePaths 省略
 
 ```bash
 # 全テスト実行
-.venv/bin/python -m pytest -q --tb=short --cov=src --cov-report=term-missing
+make test
+
+# または直接実行
+uv run pytest -q --tb=short --cov=src --cov-report=term-missing
 ```
 
-### ローカル実行
+### ローカル実行（CLI）
 
 ```bash
-.venv/bin/python -m src.app
+# 方法1: make コマンド
+make run
+
+# 方法2: uv 直接実行
+uv run python -m src.app
 ```
 
-初回実行時に `DATABASE_PATH` で指定した SQLite ファイルと必要テーブルを自動生成する。
+初回実行時に `DATABASE_PATH` で指定した SQLite ファイルと必要テーブルを自動生成する.
+
+### Docker での実行
+
+```bash
+# ステップ1: Docker イメージをビルド
+make docker-build
+
+# ステップ2: Docker コンテナを実行
+make docker-run
+```
+
+または手動で:
+
+```bash
+docker build -t mirastudy:latest .
+docker run --rm --env-file .env -v "$(pwd)/data:/app/data" mirastudy:latest
+```
+
+**注意:**
+- `.env` が存在することを確認してから実行してください（ない場合は `cp .env.example .env` で作成）
+- `data/` ディレクトリはホストマシンの同名ディレクトリにマウントされます（永続化のため）
 
 ### SQLite の確認
 
@@ -97,7 +143,7 @@ sqlite3 data/mirastudy.db "SELECT count(*) FROM learning_progress;"
 
 ```bash
 # 禁止操作・秘密情報検出
-.venv/bin/python ci/policy_check.py
+uv run python ci/policy_check.py
 ```
 
 ## 生成物の扱い

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,168 @@
+"""observability/tracing モジュールのテスト。
+
+OTel SDK 未インストール環境（_HAS_OTEL = False）でも全テストが通過することを確認する。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_init_tracer_no_exception() -> None:
+    """init_tracer() が OTel 未インストール時に例外を出さないことを確認する。"""
+    from src.observability.tracing import init_tracer
+
+    # OTel 未インストールでも例外が発生しないこと（no-op 動作）
+    init_tracer()
+    init_tracer(service_name="test-service")
+    init_tracer(service_name="test-service", enable_console_export=False)
+
+
+def test_get_tracer_returns_none_without_otel() -> None:
+    """get_tracer() が OTel 未インストール時に None を返すことを確認する。"""
+    from src.observability.tracing import _HAS_OTEL, get_tracer
+
+    if not _HAS_OTEL:
+        assert get_tracer() is None
+
+
+def test_trace_agent_operation_passthrough() -> None:
+    # OTel 未インストール時にパススルー動作することを確認する
+    """trace_agent_operation パススルー動作テスト。"""
+    from src.observability.tracing import trace_agent_operation
+
+    @trace_agent_operation("test.operation")
+    def sample_func(x: int, y: int) -> int:
+        return x + y
+
+    result = sample_func(2, 3)
+    assert result == 5
+
+
+def test_trace_agent_operation_passthrough_no_name() -> None:
+    """trace_agent_operation をデコレータ名なしで使用した場合もパススルーすることを確認する。"""
+    from src.observability.tracing import trace_agent_operation
+
+    @trace_agent_operation()
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    assert add(10, 20) == 30
+
+
+def test_trace_llm_call_passthrough() -> None:
+    """trace_llm_call デコレータが OTel 未インストール時にパススルー動作することを確認する。"""
+    from src.observability.tracing import trace_llm_call
+
+    @trace_llm_call(model_name="gemini")
+    def fake_llm(prompt: str) -> str:
+        return f"response:{prompt}"
+
+    result = fake_llm("hello")
+    assert result == "response:hello"
+
+
+def test_trace_llm_call_passthrough_no_model() -> None:
+    """trace_llm_call をモデル名なしで使用した場合もパススルーすることを確認する。"""
+    from src.observability.tracing import trace_llm_call
+
+    @trace_llm_call()
+    def fake_llm_no_model(value: int) -> int:
+        return value * 2
+
+    assert fake_llm_no_model(5) == 10
+
+
+def test_trace_tool_execution_passthrough() -> None:
+    # OTel 未インストール時にパススルー動作することを確認する
+    """trace_tool_execution パススルー動作テスト。"""
+    from src.observability.tracing import trace_tool_execution
+
+    @trace_tool_execution("test.tool")
+    def sample_tool(data: list[int]) -> int:
+        return sum(data)
+
+    assert sample_tool([1, 2, 3]) == 6
+
+
+def test_trace_tool_execution_passthrough_no_name() -> None:
+    """trace_tool_execution をツール名なしで使用した場合もパススルーすることを確認する。"""
+    from src.observability.tracing import trace_tool_execution
+
+    @trace_tool_execution()
+    def another_tool() -> str:
+        return "ok"
+
+    assert another_tool() == "ok"
+
+
+def test_trace_llm_call_preserves_exception() -> None:
+    """trace_llm_call デコレータが例外を透過的に再送出することを確認する。"""
+    from src.observability.tracing import trace_llm_call
+
+    @trace_llm_call(model_name="gemini")
+    def failing_llm() -> str:
+        raise ValueError("LLM エラー")
+
+    with pytest.raises(ValueError, match="LLM エラー"):
+        failing_llm()
+
+
+# ---------------------------------------------------------------------------
+# 統合テスト: 各サービスへのデコレータ適用確認（OTel 未インストール時のパススルー）
+# ---------------------------------------------------------------------------
+
+
+def test_auth_service_sign_in_works_with_decorator() -> None:
+    """AuthService.sign_in_with_google が @trace_agent_operation 適用後も正常動作するか確認。"""
+    from src.auth.service import AuthService
+
+    svc = AuthService(mode="mock")
+    result = svc.sign_in_with_google()
+    assert result is not None
+    assert result["uid"] == "mock_uid_001"
+
+
+def test_gemini_service_generate_question_works_with_decorator() -> None:
+    """GeminiService.generate_question が @trace_llm_call 適用後も正常動作することを確認する。"""
+    from unittest.mock import patch
+
+    from src.gemini.service import GeminiService
+
+    svc = GeminiService(api_key="test-key")
+    mock_response = {
+        "question": {"text": "テスト問題"},
+        "answer": "テスト答え",
+        "hints": [],
+        "curriculum_reference": "テスト",
+    }
+    with patch.object(svc, "generate_question", return_value=mock_response):
+        result = svc.generate_question("context", "topic", 3)
+    assert result is not None
+    assert result["question"]["text"] == "テスト問題"
+
+
+def test_learning_service_generate_question_works_with_decorator() -> None:
+    """LearningService.generate_question が @trace_llm_call 適用後も正常動作することを確認する。"""
+    from unittest.mock import MagicMock, patch
+
+    from src.domain.learning import Subject
+    from src.learning.service import LearningService
+    from src.user.profile import UserProfileService
+
+    profile = UserProfileService(":memory:")
+    gemini = MagicMock()
+    svc = LearningService(profile_service=profile, gemini_service=gemini)
+
+    mock_response = {
+        "question": {"text": "算数問題"},
+        "answer": "42",
+        "hints": [],
+        "curriculum_reference": "小学1年生算数",
+    }
+    gemini.generate_question.return_value = mock_response
+
+    with patch.object(profile, "set_learning_progress", return_value=True):
+        result = svc.generate_question("uid_001", 1, Subject.MATH, "足し算")
+    assert result["question"]["text"] == "算数問題"
+    profile.close()


### PR DESCRIPTION
## 概要

N-010「NFR-030 CLI/runbook 整備（1コマンド実行・Docker 対応）」：開発効率と運用の再現性を向上させるため、Makefile でワンコマンド実行と Docker コンテナ環境を整備した。

## 変更内容

- `Makefile` — 新規作成（setup/run/lint/format/typecheck/test/ci/docker-build/docker-run ターゲット）
- `Dockerfile` — 新規作成（python:3.11-slim ベース、uv + 依存インストール、appuser で実行）
- `docs/runbook.md` — ローカル実行（make run）・Docker 実行（make docker-build/run）手順を追記

## 動作確認

| チェック | 結果 |
|---|---|
| `make lint` | ✅ All checks passed |
| `make format` | ✅ 55 files already formatted |
| `make typecheck` | ✅ no issues found in 52 source files |
| `make test` | ✅ 190 passed |
| `make ci` | ✅ 全ステップ完了 |
| Coverage | ✅ 97.30%（閾値 80%） |
| `make run` | ✅ ローカル実行成功 |

## Docker 対応

- `docker build -t mirastudy:latest .` でイメージビルド可能
- `docker run` コマンドで `.env` マウント・`data/` ボリューム永続化対応

## 変更による影響範囲

- 開発コマンド簡略化（従来の `.venv/bin/python -m pytest` → `make test`）
- Docker 環境での実行が可能になり、CI/CD 環境での再現性向上
- runbook.md に「ローカル実行」「Docker 実行」の2パターンを記載

Closes #13
