### PR TITLE
refactor(N-014): app.py 重複排除・ログ構造化・web/app.py セキュリティ修正

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -40,20 +40,20 @@ def main() -> None:
     _setup_logging(config.log_level)
     profile_service: UserProfileService | None = None
 
-    print("=== MiraStudy CLI ===")
+    logger.info("=== MiraStudy CLI ===")
     try:
         # AUTH_MODE に応じた認証サービスを初期化する
         auth = AuthService(mode=config.auth_mode)
         user = auth.sign_in_with_google()
         if user is None:
             raise AuthenticationError("サインインに失敗しました")
-        print("ログイン成功")
+        logger.info("ログイン成功")
 
         # プロファイル管理
         profile_service = UserProfileService(db_path=config.database_path)
         profile_service.set_profile(user["uid"], user)
         profile = profile_service.get_profile(user["uid"])
-        print("プロファイルを保存しました")
+        logger.info("プロファイルを保存しました")
 
         # 権限判定: VIEW_KNOWLEDGE がなければ処理を停止する
         # profile が None は異常状態（フェイルクローズ P-010）
@@ -62,52 +62,34 @@ def main() -> None:
         role = profile.get("role", "student")
         if not has_permission(role, Permission.VIEW_KNOWLEDGE):
             raise AuthorizationError(f"ロール '{role}' は VIEW_KNOWLEDGE 権限を持っていません")
-        print("知識共有フォルダ閲覧権限あり")
+        logger.info("知識共有フォルダ閲覧権限あり")
 
         # Drive連携
         drive = DriveService()
         pdfs = drive.list_pdfs_in_folder(config.drive_folder_id)
-        print(f"PDF一覧: {pdfs}")
+        logger.info("PDF一覧: %s", pdfs)
         meta = drive.get_metadata(config.drive_folder_id, config.gemini_topic)
-        print(f"metadata: {meta}")
+        logger.info("metadata: %s", meta)
 
-        # Gemini API連携
+        # GeminiService 初期化（LearningService に注入する）
         gemini = GeminiService(api_key=config.api_key)
-        question = gemini.generate_question(
-            "PDFコンテキスト", config.gemini_topic, config.gemini_grade
-        )
-        if question is None:
-            raise ValidationError("Gemini から問題を取得できませんでした")
-        print(f"Gemini生成問題: {question}")
 
-        progress = {
-            "topic": config.gemini_topic,
-            "grade": config.gemini_grade,
-            "status": "generated",
-            "lastQuestion": question["question"]["text"],
-        }
-        profile_service.set_learning_progress(user["uid"], config.gemini_topic, progress)
-        saved_progress = profile_service.get_learning_progress(user["uid"], config.gemini_topic)
-        if saved_progress is None:
-            raise ValidationError("学習進捗を再取得できませんでした")
-        print("学習進捗を保存しました")
-
-        # 学習機能: 学年別コンテンツ配信・問題生成
+        # 学習機能: 学年別コンテンツ配信・問題生成（LearningService 経由で実施）
         learning = LearningService(
             profile_service=profile_service,
             gemini_service=gemini,
         )
         content = learning.get_content_for_grade(config.gemini_grade, Subject.MATH)
         if content is not None:
-            print(f"学年コンテンツ: {content.title}")
+            logger.info("学年コンテンツ: %s", content.title)
 
         topic_key = config.gemini_topic
         learning.generate_question(user["uid"], config.gemini_grade, Subject.MATH, topic_key)
-        print("学習問題を生成しました")
+        logger.info("学習問題を生成しました")
 
         learning.record_answer(user["uid"], Subject.MATH, topic_key, is_correct=True)
         summary = learning.get_progress_summary(user["uid"], Subject.MATH)
-        print(f"進捗サマリー: {summary}")
+        logger.info("進捗サマリー: %s", summary)
 
     except AuthenticationError as e:
         logger.error("認証エラー: %s", e)

--- a/tests/test_app_error_handling.py
+++ b/tests/test_app_error_handling.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 if TYPE_CHECKING:
     import pytest
 
-from src.app import main
+from src.app import _setup_logging, main
 from src.core.exceptions import (
     AuthenticationError,
     AuthorizationError,
@@ -119,3 +120,33 @@ def test_main_raises_authorization_error_when_profile_missing(
         mock_profile_service.return_value.get_profile.return_value = None
         with _pytest.raises(AuthorizationError):
             main()
+
+
+# ---- N-014: _setup_logging 専用テスト ----
+
+
+def test_setup_logging_valid_level() -> None:
+    """有効なレベル文字列を渡すと basicConfig が正しいレベルで呼ばれる。"""
+    with patch("logging.basicConfig") as mock_basicconfig:
+        _setup_logging("DEBUG")
+    mock_basicconfig.assert_called_once()
+    _, kwargs = mock_basicconfig.call_args
+    assert kwargs["level"] == logging.DEBUG
+
+
+def test_setup_logging_invalid_level_falls_back_to_info() -> None:
+    """無効なレベル文字列を渡すと basicConfig が INFO で呼ばれる（フォールバック）。"""
+    with patch("logging.basicConfig") as mock_basicconfig:
+        _setup_logging("INVALID_LEVEL_XYZ")
+    mock_basicconfig.assert_called_once()
+    _, kwargs = mock_basicconfig.call_args
+    assert kwargs["level"] == logging.INFO
+
+
+def test_setup_logging_case_insensitive() -> None:
+    """レベル文字列は大文字小文字を区別しない。"""
+    with patch("logging.basicConfig") as mock_basicconfig:
+        _setup_logging("warning")
+    mock_basicconfig.assert_called_once()
+    _, kwargs = mock_basicconfig.call_args
+    assert kwargs["level"] == logging.WARNING

--- a/web/app.py
+++ b/web/app.py
@@ -2,36 +2,69 @@
 MiraStudy Webアプリ（Flask雛形）
 """
 
-from flask import Flask, render_template_string
+import logging
+import os
+
+from flask import Flask, abort, render_template_string
 from src.auth.service import AuthService
+from src.core.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    DomainError,
+    ValidationError,
+)
 from src.drive.service import DriveService
 from src.gemini.service import GeminiService
 from src.user.profile import UserProfileService
 
 app = Flask(__name__)
-API_KEY = "dummy-key"
+# MUST-1: APIキーは環境変数から読み込む（P-002準拠）
+API_KEY = os.environ.get("GEMINI_API_KEY", "")
+
+logger = logging.getLogger(__name__)
 
 
 @app.route("/")
 def index():
     auth = AuthService()
+    # MUST-3: sign_in_with_google() の None ガード
     user = auth.sign_in_with_google()
+    if user is None:
+        raise AuthenticationError("Googleサインインに失敗しました")
+
     profile_service = UserProfileService()
-    profile_service.set_profile(user["uid"], user)
-    profile = profile_service.get_profile(user["uid"])
-    drive = DriveService()
-    pdfs = drive.list_pdfs_in_folder("folder1")
-    gemini = GeminiService(api_key=API_KEY)
-    question = gemini.generate_question("PDFコンテキスト", "算数", 3)
-    html = f"""
-    <h1>MiraStudy Web</h1>
-    <p>ログイン: {user["displayName"]} ({user["email"]})</p>
-    <p>プロファイル: {profile}</p>
-    <p>PDF一覧: {pdfs}</p>
-    <p>Gemini生成問題: {question}</p>
-    """
-    return render_template_string(html)
+    try:
+        profile_service.set_profile(user["uid"], user)
+        profile = profile_service.get_profile(user["uid"])
+        drive = DriveService()
+        pdfs = drive.list_pdfs_in_folder("folder1")
+        gemini = GeminiService(api_key=API_KEY)
+        question = gemini.generate_question("PDFコンテキスト", "算数", 3)
+
+        # MUST-2: XSS対策 - Jinja2変数展開で自動エスケープを使用
+        html = """
+<h1>MiraStudy Web</h1>
+<p>ログイン: {{ display_name }} ({{ email }})</p>
+<p>プロファイル: {{ profile }}</p>
+<p>PDF一覧: {{ pdfs }}</p>
+<p>Gemini生成問題: {{ question }}</p>
+"""
+        return render_template_string(
+            html,
+            display_name=user["displayName"],
+            email=user["email"],
+            profile=profile,
+            pdfs=pdfs,
+            question=question,
+        )
+    except (AuthenticationError, AuthorizationError, ValidationError, DomainError) as e:
+        logger.error("ドメインエラー: %s", e)
+        abort(500)
+    finally:
+        # MUST-3: finally で close() を保証
+        profile_service.close()
 
 
 if __name__ == "__main__":
-    app.run(debug=True, host="0.0.0.0", port=5001)
+    # デバッグモードは環境変数で制御
+    app.run(debug=os.environ.get("FLASK_DEBUG", "0") == "1", host="0.0.0.0", port=5001)


### PR DESCRIPTION
## 概要

N-014: `src/app.py` の重複ロジック削除・`print()` → `logger` 置き換え、および `web/app.py` のセキュリティ・信頼性問題修正。

Closes #22

## 変更内容

### src/app.py
- 直接 `gemini.generate_question()` 呼び出しブロック（ValidationError チェック含む）を削除し、`LearningService` に一本化
- 直接 `profile_service.set_learning_progress()` / `get_learning_progress()` の重複呼び出しを削除
- 全 `print()` 8箇所を `logger.info()` / `logger.error()` に置き換え
- `_setup_logging()` 関数を整備

### web/app.py（監査指摘 Must 対応）
- P-002: `API_KEY = "dummy-key"` ハードコードを `os.environ.get("GEMINI_API_KEY", "")` に変更
- OWASP A03: f-string XSS → `render_template_string` の Jinja2 変数展開（自動エスケープ）に変更
- P-010: `sign_in_with_google()` 返値 None ガード追加
- 例外キャッチ + 500 レスポンス追加
- `profile_service.close()` を `finally` ブロックで保証
- `app.run(debug=True)` を `FLASK_DEBUG` 環境変数で制御

## 検証結果

| チェック | 結果 |
|---|---|
| `make ci`（lint/type/test/policy） | ✅ 全通過 |
| テスト数 | 212 passed（新規 3 追加） |
| カバレッジ | 93.22% |
| 仕様監査（Must） | 0件 |
| セキュリティ監査（Must） | 0件（修正済み） |
| 信頼性監査（Must） | 0件（修正済み） |

## 検証手順

```bash
git checkout feature/n-014-log-cleanup
source .venv/bin/activate
make ci
```
