### PR TITLE
test(N-019): カバレッジ補強（権限型ガード・設定不正値フォールバック）

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -112,3 +112,12 @@ def test_config_database_path_invalid_falls_back_to_default(
     config = AppConfig.from_env()
 
     assert config.database_path == "data/mirastudy.db"
+
+
+def test_config_invalid_auth_mode_falls_back_to_mock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AUTH_MODE に無効値が設定された場合は 'mock' にフォールバックする。"""
+    monkeypatch.setenv("AUTH_MODE", "invalid_mode")
+
+    config = AppConfig.from_env()
+
+    assert config.auth_mode == "mock"

--- a/tests/test_permissions_roles.py
+++ b/tests/test_permissions_roles.py
@@ -66,3 +66,9 @@ def test_unknown_role_has_no_permissions() -> None:
     """存在しないロールはいかなる権限も持たない。"""
     for perm in Permission:
         assert not has_permission("unknown_role", perm), f"未知ロールが {perm} を持っている"
+
+
+def test_non_string_role_returns_false() -> None:
+    """user_role が str 以外の場合は False を返す（型ガード）。"""
+    assert not has_permission(None, Permission.VIEW_KNOWLEDGE)  # type: ignore[arg-type]
+    assert not has_permission(123, Permission.VIEW_KNOWLEDGE)  # type: ignore[arg-type]


### PR DESCRIPTION
## 概要

N-019: テスト補強。`has_permission` の型ガードと `AppConfig.from_env()` の不正 `AUTH_MODE` フォールバックをカバーするテストを追加する。

Closes #27

## 変更内容

### tests/test_permissions_roles.py
- `test_non_string_role_returns_false()` 追加：`user_role` が `None` や `int` の場合に `False` を返すことを検証（line 38 の型チェックをカバー）

### tests/test_config.py
- `test_config_invalid_auth_mode_falls_back_to_mock()` 追加：`AUTH_MODE=invalid_mode` 設定時に `"mock"` にフォールバックすることを検証（line 65-70 をカバー）

## 検証結果

| チェック | 結果 |
|---|---|
| `make ci` | ✅ 全通過 |
| テスト数 | 211 passed |
| カバレッジ | 93.63% |

## 検証手順

```bash
git checkout feature/n-019-test-strengthen
source .venv/bin/activate
make ci
```
