### PR TITLE
feat(gemini): N-023 GeminiService google-generativeai SDK 統合

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -26,7 +26,10 @@ _DEFAULT_GENAI_RESPONSE = {
 
 @pytest.fixture(autouse=True)
 def _mock_genai_globally(monkeypatch: pytest.MonkeyPatch) -> None:
-    """CI で google-generativeai なしに全テストが通るよう genai をモックする。"""
+    """外部 API を呼び出さないよう全テストで genai をモックする。
+    個別テストで patch(...) を使う場合はそちらが優先される。
+    SDK 未インストール時の挙動を検証したいテストは _GENAI_AVAILABLE=False を直接パッチする。
+    """
     mock_response = MagicMock()
     mock_response.text = json.dumps(_DEFAULT_GENAI_RESPONSE)
     mock_response.candidates = []

--- a/conftest.py
+++ b/conftest.py
@@ -9,8 +9,8 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent / "src"))
 
-# CI 環境では google-generativeai が未インストールのため、
-# 全テストでデフォルトモックを適用する。
+# google-generativeai は pyproject.toml の依存に含まれ CI でもインストール済みだが、
+# 外部 API を呼び出さないよう全テストでデフォルトモックを適用する。
 # 個別テストで patch(...) を使う場合はそちらが優先される。
 _DEFAULT_GENAI_RESPONSE = {
     "question": {

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,38 @@
 """pytest 設定。src/ を sys.path に追加してパッケージを解決する。"""
 
+import json
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+# CI 環境では google-generativeai が未インストールのため、
+# 全テストでデフォルトモックを適用する。
+# 個別テストで patch(...) を使う場合はそちらが優先される。
+_DEFAULT_GENAI_RESPONSE = {
+    "question": {
+        "text": "算数に関する問題（3年）",
+        "type": "choice",
+        "options": ["A", "B", "C"],
+    },
+    "answer": {"correct": "A", "explanation": "Aが正解です。"},
+    "hints": {"level1": "ヒント1", "level2": "ヒント2", "level3": "ヒント3"},
+    "curriculum_reference": {"chapter": "第1章", "section": "1節", "page": 10},
+}
+
+
+@pytest.fixture(autouse=True)
+def _mock_genai_globally(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CI で google-generativeai なしに全テストが通るよう genai をモックする。"""
+    mock_response = MagicMock()
+    mock_response.text = json.dumps(_DEFAULT_GENAI_RESPONSE)
+    mock_response.candidates = []
+
+    mock_genai = MagicMock()
+    mock_genai.GenerativeModel.return_value.generate_content.return_value = mock_response
+
+    monkeypatch.setattr("src.gemini.service._GENAI_AVAILABLE", True)
+    monkeypatch.setattr("src.gemini.service.genai", mock_genai)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.11"
 dependencies = [
     "flask>=3.0",
     "google-auth-oauthlib>=1.2.0",
+    "google-generativeai>=0.7",
 ]
 
 [project.optional-dependencies]

--- a/src/gemini/service.py
+++ b/src/gemini/service.py
@@ -39,6 +39,7 @@ class GeminiService:
         RuntimeError / OSError / ConnectionError / TimeoutError 発生時は
         指数バックオフ（1s, 2s, 4s）で最大3回リトライする。
         ValidationError / ValueError は即座に再送出する（リトライしない）。
+        上記以外の想定外例外（TypeError, AttributeError 等）も即座に再送出する（リトライしない）。
         """
         # SDK 未インストール時は即座にエラーを送出する
         if not _GENAI_AVAILABLE or genai is None:
@@ -89,6 +90,7 @@ class GeminiService:
                 # 上記例外のみリトライ対象とし、それ以外は即座に再送出する
                 last_exc = exc
             except Exception:
+                # TypeError / AttributeError 等の想定外例外はリトライせず即座に再送出する
                 raise
         # すべてのリトライが失敗した場合は最後の例外を再送出する
         if last_exc is not None:

--- a/src/gemini/service.py
+++ b/src/gemini/service.py
@@ -1,9 +1,10 @@
 """
-Gemini API連携サービス雛形
+Gemini API連携サービス
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 
@@ -15,11 +16,22 @@ logger = logging.getLogger(__name__)
 # リトライ間隔（秒）：指数バックオフ
 RETRY_INTERVALS = (1, 2, 4)
 
+# google-generativeai SDK の条件付きインポート
+try:
+    import google.generativeai as genai
+
+    _GENAI_AVAILABLE = True
+except ImportError:
+    genai = None  # type: ignore[assignment]
+    _GENAI_AVAILABLE = False
+
 
 class GeminiService:
     def __init__(self, api_key: str):
         self.api_key = api_key
-        # 実際はGoogle Generative AI SDK初期化
+        # SDK が利用可能な場合は API キーを設定する
+        if _GENAI_AVAILABLE and genai is not None:
+            genai.configure(api_key=api_key)
 
     @trace_llm_call(model_name="gemini")
     def generate_question(self, context: str, topic: str, grade: int) -> dict | None:
@@ -28,6 +40,10 @@ class GeminiService:
         指数バックオフ（1s, 2s, 4s）で最大3回リトライする。
         ValidationError / ValueError は即座に再送出する（リトライしない）。
         """
+        # SDK 未インストール時は即座にエラーを送出する
+        if not _GENAI_AVAILABLE or genai is None:
+            raise RuntimeError("google-generativeai パッケージが未インストールです")
+
         last_exc: Exception | None = None
         # 初回試行（wait=-1）＋最大3回リトライ
         for attempt, wait in enumerate((-1,) + RETRY_INTERVALS, start=1):
@@ -35,17 +51,37 @@ class GeminiService:
                 logger.warning("Gemini API 再試行 %d回目（待機 %ds）: %s", attempt, wait, last_exc)
                 time.sleep(wait)
             try:
-                # 実際はAPI呼び出し（将来の実装でリトライが機能する）
-                return {
-                    "question": {
-                        "text": f"{topic}に関する問題（{grade}年）",
-                        "type": "choice",
-                        "options": ["A", "B", "C"],
-                    },
-                    "answer": {"correct": "A", "explanation": "Aが正解です。"},
-                    "hints": {"level1": "ヒント1", "level2": "ヒント2", "level3": "ヒント3"},
-                    "curriculum_reference": {"chapter": "第1章", "section": "1節", "page": 10},
-                }
+                model = genai.GenerativeModel("gemini-1.5-flash")
+                prompt = (
+                    f"あなたは日本の小学校の教師です。{grade}年生の{topic}に関する選択式問題を1問作成してください。\n"
+                    f"コンテキスト: {context}\n"
+                    "以下のJSON形式で回答してください（他のテキストは含めないこと）:\n"
+                    '{"question":{"text":"問題文","type":"choice","options":["A","B","C"]},'
+                    '"answer":{"correct":"A","explanation":"解説"},'
+                    '"hints":{"level1":"ヒント1","level2":"ヒント2","level3":"ヒント3"},'
+                    '"curriculum_reference":{"chapter":"第1章","section":"1節","page":1}}'
+                )
+                response = model.generate_content(prompt)
+                # 安全フィルタ違反チェック（C-002 準拠）
+                if hasattr(response, "candidates") and response.candidates:
+                    candidate = response.candidates[0]
+                    if hasattr(candidate, "finish_reason") and str(candidate.finish_reason) in (
+                        "FinishReason.SAFETY",
+                        "SAFETY",
+                    ):
+                        raise ValidationError(
+                            "Gemini API: コンテンツ安全フィルタにより生成を拒否しました（C-002）"
+                        )
+                # レスポンスからテキストを取得して JSON パースする
+                text = response.text.strip()
+                # Markdown コードブロックを除去する
+                if text.startswith("```"):
+                    lines = text.split("\n")
+                    text = "\n".join(lines[1:-1] if lines[-1] == "```" else lines[1:])
+                return json.loads(text)
+            except json.JSONDecodeError as exc:
+                # JSONDecodeError は ValueError のサブクラスなので先に捕捉してラップする
+                raise ValidationError(f"Gemini API レスポンスの JSON パースに失敗: {exc}") from exc
             except (ValidationError, ValueError):
                 # バリデーションエラーはリトライせず即座に再送出する
                 raise

--- a/src/gemini/service.py
+++ b/src/gemini/service.py
@@ -85,8 +85,11 @@ class GeminiService:
             except (ValidationError, ValueError):
                 # バリデーションエラーはリトライせず即座に再送出する
                 raise
-            except Exception as exc:
+            except (RuntimeError, OSError, ConnectionError, TimeoutError) as exc:
+                # 上記例外のみリトライ対象とし、それ以外は即座に再送出する
                 last_exc = exc
+            except Exception:
+                raise
         # すべてのリトライが失敗した場合は最後の例外を再送出する
         if last_exc is not None:
             raise last_exc

--- a/tests/test_gemini_service.py
+++ b/tests/test_gemini_service.py
@@ -1,17 +1,116 @@
 """
-src/gemini/service.py のGemini API連携サービス雛形テスト
+src/gemini/service.py の Gemini API 連携サービステスト
 """
 
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from src.core.exceptions import ValidationError
 from src.gemini.service import GeminiService
 
+# テスト用の正常レスポンス JSON
+_VALID_RESPONSE = {
+    "question": {"text": "テスト問題", "type": "choice", "options": ["A", "B", "C"]},
+    "answer": {"correct": "A", "explanation": "解説"},
+    "hints": {"level1": "H1", "level2": "H2", "level3": "H3"},
+    "curriculum_reference": {"chapter": "第1章", "section": "1節", "page": 1},
+}
 
-def test_generate_question():
-    gemini = GeminiService(api_key="dummy-key")
-    result = gemini.generate_question("PDFコンテキスト", "算数", 3)
+
+def _make_mock_response(text: str, candidates=None):
+    """モックレスポンスを生成するヘルパー。"""
+    mock_response = MagicMock()
+    mock_response.text = text
+    mock_response.candidates = candidates if candidates is not None else []
+    return mock_response
+
+
+def test_generate_question_with_mock_genai():
+    """正常系: モック genai でJSONレスポンスが正しくパースされることを確認する。"""
+    mock_response = _make_mock_response(json.dumps(_VALID_RESPONSE))
+
+    with (
+        patch("src.gemini.service.genai") as mock_genai,
+        patch("src.gemini.service._GENAI_AVAILABLE", True),
+    ):
+        mock_genai.GenerativeModel.return_value.generate_content.return_value = mock_response
+        mock_genai.configure = MagicMock()
+        service = GeminiService(api_key="test-key")
+        result = service.generate_question("PDFコンテキスト", "算数", 3)
+
     assert result is not None
-    assert "question" in result
-    assert "answer" in result
     assert result["question"]["type"] == "choice"
     assert result["answer"]["correct"] == "A"
     assert "hints" in result
     assert "curriculum_reference" in result
+
+
+def test_generate_question_safety_filter():
+    """安全フィルタ違反時に ValidationError が送出されることを確認する（C-002 準拠）。"""
+    mock_candidate = MagicMock()
+    mock_candidate.finish_reason = "SAFETY"
+    mock_response = _make_mock_response("", candidates=[mock_candidate])
+
+    with (
+        patch("src.gemini.service.genai") as mock_genai,
+        patch("src.gemini.service._GENAI_AVAILABLE", True),
+    ):
+        mock_genai.GenerativeModel.return_value.generate_content.return_value = mock_response
+        mock_genai.configure = MagicMock()
+        service = GeminiService(api_key="test-key")
+        with pytest.raises(ValidationError, match="安全フィルタ"):
+            service.generate_question("コンテキスト", "国語", 1)
+
+
+def test_generate_question_json_parse_error():
+    """JSONパース失敗時に ValidationError が送出されることを確認する。"""
+    mock_response = _make_mock_response("not a json")
+
+    with (
+        patch("src.gemini.service.genai") as mock_genai,
+        patch("src.gemini.service._GENAI_AVAILABLE", True),
+    ):
+        mock_genai.GenerativeModel.return_value.generate_content.return_value = mock_response
+        mock_genai.configure = MagicMock()
+        service = GeminiService(api_key="test-key")
+        with pytest.raises(ValidationError, match="JSON パースに失敗"):
+            service.generate_question("コンテキスト", "理科", 4)
+
+
+def test_generate_question_retry_on_runtime_error():
+    """RuntimeError 発生時に指数バックオフでリトライされることを確認する。"""
+    with (
+        patch("src.gemini.service.genai") as mock_genai,
+        patch("src.gemini.service._GENAI_AVAILABLE", True),
+        patch("src.gemini.service.time.sleep") as mock_sleep,
+    ):
+        mock_genai.configure = MagicMock()
+        mock_genai.GenerativeModel.return_value.generate_content.side_effect = RuntimeError(
+            "API 一時エラー"
+        )
+        service = GeminiService(api_key="test-key")
+        with pytest.raises(RuntimeError, match="API 一時エラー"):
+            service.generate_question("コンテキスト", "社会", 5)
+
+    # リトライ間隔（1s, 2s, 4s）分だけ sleep が呼ばれることを確認する
+    assert mock_sleep.call_count == 3
+
+
+def test_generate_question_validation_error_no_retry():
+    """ValidationError 発生時はリトライなしで即座に再送出されることを確認する。"""
+    with (
+        patch("src.gemini.service.genai") as mock_genai,
+        patch("src.gemini.service._GENAI_AVAILABLE", True),
+        patch("src.gemini.service.time.sleep") as mock_sleep,
+    ):
+        mock_genai.configure = MagicMock()
+        mock_genai.GenerativeModel.return_value.generate_content.side_effect = ValidationError(
+            "バリデーションエラー"
+        )
+        service = GeminiService(api_key="test-key")
+        with pytest.raises(ValidationError, match="バリデーションエラー"):
+            service.generate_question("コンテキスト", "英語", 6)
+
+    # sleep は一切呼ばれないことを確認する
+    mock_sleep.assert_not_called()

--- a/tests/test_gemini_service.py
+++ b/tests/test_gemini_service.py
@@ -114,3 +114,62 @@ def test_generate_question_validation_error_no_retry():
 
     # sleep は一切呼ばれないことを確認する
     mock_sleep.assert_not_called()
+
+
+def test_init_calls_genai_configure():
+    """__init__ で genai.configure(api_key=...) が正しいキーで呼ばれることを確認する。"""
+    with (
+        patch("src.gemini.service.genai") as mock_genai,
+        patch("src.gemini.service._GENAI_AVAILABLE", True),
+    ):
+        mock_genai.configure = MagicMock()
+        GeminiService(api_key="my-secret-key")
+        mock_genai.configure.assert_called_once_with(api_key="my-secret-key")
+
+
+def test_generate_question_sdk_not_available():
+    """SDK 未インストール時に RuntimeError が即座に送出されることを確認する。"""
+    with (
+        patch("src.gemini.service._GENAI_AVAILABLE", False),
+        patch("src.gemini.service.genai", None),
+    ):
+        service = GeminiService(api_key="test-key")
+        with pytest.raises(RuntimeError, match="未インストール"):
+            service.generate_question("コンテキスト", "算数", 3)
+
+
+def test_generate_question_markdown_code_fence():
+    """レスポンスが Markdown コードフェンスで囲まれていても正しくパースされることを確認する。"""
+    fenced_text = "```json\n" + json.dumps(_VALID_RESPONSE) + "\n```"
+    mock_response = _make_mock_response(fenced_text)
+
+    with (
+        patch("src.gemini.service.genai") as mock_genai,
+        patch("src.gemini.service._GENAI_AVAILABLE", True),
+    ):
+        mock_genai.GenerativeModel.return_value.generate_content.return_value = mock_response
+        mock_genai.configure = MagicMock()
+        service = GeminiService(api_key="test-key")
+        result = service.generate_question("コンテキスト", "理科", 2)
+
+    assert result is not None
+    assert result["question"]["text"] == "テスト問題"
+
+
+def test_generate_question_unexpected_exception_no_retry():
+    """想定外例外（AttributeError 等）はリトライせず即座に再送出されることを確認する。"""
+    with (
+        patch("src.gemini.service.genai") as mock_genai,
+        patch("src.gemini.service._GENAI_AVAILABLE", True),
+        patch("src.gemini.service.time.sleep") as mock_sleep,
+    ):
+        mock_genai.configure = MagicMock()
+        mock_genai.GenerativeModel.return_value.generate_content.side_effect = AttributeError(
+            "想定外エラー"
+        )
+        service = GeminiService(api_key="test-key")
+        with pytest.raises(AttributeError, match="想定外エラー"):
+            service.generate_question("コンテキスト", "算数", 3)
+
+    # リトライしないので sleep は呼ばれない
+    mock_sleep.assert_not_called()

--- a/tests/test_gemini_service.py
+++ b/tests/test_gemini_service.py
@@ -1,5 +1,5 @@
 """
-src/gemini/service.py の Gemini API 連携サービステスト
+src/gemini/service.py の GeminiService テスト
 """
 
 import json


### PR DESCRIPTION
## 概要

`GeminiService` のスタブ実装（ハードコードされたダミーレスポンス）を `google-generativeai` SDK による実 API 呼び出しに置き換えました。CI ではすべてモックを使用します。

Closes #37

> ⚠️ **マージ順序**: このPRは PR #41（N-021）と PR #42（N-022）のマージ後にマージしてください。constraints.md の C-002 定義（N-021）が master に取り込まれてから本変更が有効になります。

## 変更内容

### src/gemini/service.py
- `google-generativeai` SDK の条件付きインポート（`_GENAI_AVAILABLE` フラグ）
- `GeminiService.__init__` で `genai.configure(api_key=api_key)` 呼び出し
- `generate_question` を `GenerativeModel.generate_content()` に置き換え
- **C-002 準拠**: `finish_reason == SAFETY` 時に `ValidationError` 送出
- JSON パースエラーを `ValidationError` にラップ
- Markdown コードブロック（` ``` `）の自動除去
- SDK 未インストール時は `RuntimeError` を即送出（P-010）

### tests/test_gemini_service.py（テスト追加）
- 正常系（モック genai で JSON レスポンス返却）
- 安全フィルタ（`finish_reason=SAFETY`）→ `ValidationError`
- JSON パースエラー → `ValidationError`
- `RuntimeError` 時のリトライ（`time.sleep` 呼び出し確認）
- `ValidationError` 時のリトライなし確認

### conftest.py（新規）
- CI 環境全体で `google.generativeai` をグローバルモック（autouse）

### pyproject.toml
- `google-generativeai>=0.7` を dependencies に追加

## 検証手順と結果

```
pip install google-generativeai && make ci
→ 229 passed, coverage 92.66%, gemini/service.py 86% ✅
get_errors → No errors found ✅
```

## 監査結果

| 観点 | 結果 |
|---|---|
| 信頼性（auditor-reliability） | PASS（Must なし） |
| セキュリティ（auditor-security） | PASS（Must なし） |
| 仕様整合（auditor-spec） | Must 2件 → PR #41/#42 マージ後にマージ（依存順序の問題、コード品質の問題ではない） |
